### PR TITLE
Create jar artifact in Gradle workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,3 +29,8 @@ jobs:
       uses: gradle/gradle-build-action@937999e9cc2425eddc7fd62d1053baf041147db7
       with:
         arguments: build
+    - name: Archive built JAR
+      uses: actions/upload-artifact@v3
+      with:
+        name: jyxal
+        path: build/libs/Jyxal-*-all.jar


### PR DESCRIPTION
This workflow will save the jar generated in the Gradle workflow. If someone wants the latest build, they can just grab that instead of building Jyxal themselves. You can find the jar produced by this commit [here](https://github.com/Vyxal/Jyxal/actions/runs/1936617583) (scroll to the bottom).